### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "./adventure.sh"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/apetro/BashVenture)](https://repl.it/github/apetro/BashVenture)
+
 BashVenture - Adventure for Bash
 =================================
 


### PR DESCRIPTION
Hi! I tried playing this game and thought it would be really nice to be able to make even easier to play by making it available in browser. That would make Windows users able to play without even using PuTTY :) This pull request configures this repository to be run through Repl.it. It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dialogarithm/BashVenture).
![Capture](https://user-images.githubusercontent.com/39810066/70551547-b5805000-1b45-11ea-9b58-4ee6c060da5e.PNG)
